### PR TITLE
Remove node_modules from server and git history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+server/node_modules/


### PR DESCRIPTION
Add `server/node_modules/` to `.gitignore` to prevent it from being re-added to the repository.

This change is part of a larger effort to purge `server/node_modules` from Git history, significantly reducing the repository size and improving Git performance.

---
<a href="https://cursor.com/background-agent?bcId=bc-20737807-885f-42a6-8557-6733ffc392e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-20737807-885f-42a6-8557-6733ffc392e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

